### PR TITLE
Prefer NEON over SVE on 128-bit SVE; reduce NEON horizontal reductions

### DIFF
--- a/fastops/core/SIMDFunctions.h
+++ b/fastops/core/SIMDFunctions.h
@@ -1396,12 +1396,12 @@ namespace NFastOps {
         FORCE_INLINE static int TestCF(t_f v1, t_f v2) {
             uint32x4_t bits_lo = vbicq_u32(vreinterpretq_u32_f32(v2.lo), vreinterpretq_u32_f32(v1.lo));
             uint32x4_t bits_hi = vbicq_u32(vreinterpretq_u32_f32(v2.hi), vreinterpretq_u32_f32(v1.hi));
-            return (vmaxvq_u32(bits_lo) | vmaxvq_u32(bits_hi)) == 0;
+            return vmaxvq_u32(vorrq_u32(bits_lo, bits_hi)) == 0;
         }
         FORCE_INLINE static int TestZF(t_f v1, t_f v2) {
             uint32x4_t bits_lo = vandq_u32(vreinterpretq_u32_f32(v1.lo), vreinterpretq_u32_f32(v2.lo));
             uint32x4_t bits_hi = vandq_u32(vreinterpretq_u32_f32(v1.hi), vreinterpretq_u32_f32(v2.hi));
-            return (vmaxvq_u32(bits_lo) | vmaxvq_u32(bits_hi)) == 0;
+            return vmaxvq_u32(vorrq_u32(bits_lo, bits_hi)) == 0;
         }
 
         FORCE_INLINE static t_f AndF(t_f v1, t_f v2) {
@@ -1680,14 +1680,14 @@ namespace NFastOps {
         FORCE_INLINE static int TestCF(t_f v1, t_f v2) {
             uint64x2_t bits_lo = vbicq_u64(vreinterpretq_u64_f64(v2.lo), vreinterpretq_u64_f64(v1.lo));
             uint64x2_t bits_hi = vbicq_u64(vreinterpretq_u64_f64(v2.hi), vreinterpretq_u64_f64(v1.hi));
-            return (vgetq_lane_u64(bits_lo, 0) | vgetq_lane_u64(bits_lo, 1) |
-                    vgetq_lane_u64(bits_hi, 0) | vgetq_lane_u64(bits_hi, 1)) == 0;
+            uint64x2_t combined = vorrq_u64(bits_lo, bits_hi);
+            return (vgetq_lane_u64(combined, 0) | vgetq_lane_u64(combined, 1)) == 0;
         }
         FORCE_INLINE static int TestZF(t_f v1, t_f v2) {
             uint64x2_t bits_lo = vandq_u64(vreinterpretq_u64_f64(v1.lo), vreinterpretq_u64_f64(v2.lo));
             uint64x2_t bits_hi = vandq_u64(vreinterpretq_u64_f64(v1.hi), vreinterpretq_u64_f64(v2.hi));
-            return (vgetq_lane_u64(bits_lo, 0) | vgetq_lane_u64(bits_lo, 1) |
-                    vgetq_lane_u64(bits_hi, 0) | vgetq_lane_u64(bits_hi, 1)) == 0;
+            uint64x2_t combined = vorrq_u64(bits_lo, bits_hi);
+            return (vgetq_lane_u64(combined, 0) | vgetq_lane_u64(combined, 1)) == 0;
         }
 
         FORCE_INLINE static t_f AndF(t_f v1, t_f v2) {

--- a/fastops/fastops.cpp
+++ b/fastops/fastops.cpp
@@ -7,15 +7,18 @@
 #include <fastops/sve/ops_sve.h>
 #endif
 
-// AArch64: on Linux, dispatch to SVE when available (any vector width),
-// otherwise fall back to NEON. On non-Linux AArch64 (macOS, FreeBSD),
-// SVE is not available so we go straight to NEON.
+// AArch64: on Linux, dispatch to SVE when the vector length is wider than
+// 128 bits, otherwise fall back to NEON. At 128-bit SVE width, NEON is
+// competitive or faster because it avoids movprfx overhead and the exact
+// paths have lower register pressure (no callee-save spills).
+// On non-Linux AArch64 (macOS, FreeBSD), SVE is not available so we go
+// straight to NEON.
 namespace NFastOps {
 
     template <bool I_Exact, bool I_OutAligned>
     void Exp(const float* from, size_t size, float* to) {
 #if defined(__linux__)
-        if (HaveSve()) ExpSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) ExpSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         ExpNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -24,7 +27,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Exp(const double* from, size_t size, double* to) {
 #if defined(__linux__)
-        if (HaveSve()) ExpSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) ExpSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         ExpNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -33,7 +36,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Log(const float* from, size_t size, float* to) {
 #if defined(__linux__)
-        if (HaveSve()) LogSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) LogSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         LogNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -42,7 +45,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Log(const double* from, size_t size, double* to) {
 #if defined(__linux__)
-        if (HaveSve()) LogSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) LogSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         LogNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -51,7 +54,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Sigmoid(const float* from, size_t size, float* to) {
 #if defined(__linux__)
-        if (HaveSve()) SigmoidSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) SigmoidSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         SigmoidNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -60,7 +63,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Sigmoid(const double* from, size_t size, double* to) {
 #if defined(__linux__)
-        if (HaveSve()) SigmoidSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) SigmoidSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         SigmoidNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -69,7 +72,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Tanh(const float* from, size_t size, float* to) {
 #if defined(__linux__)
-        if (HaveSve()) TanhSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) TanhSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         TanhNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -78,7 +81,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Tanh(const double* from, size_t size, double* to) {
 #if defined(__linux__)
-        if (HaveSve()) TanhSve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) TanhSve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         TanhNeon<I_Exact, I_OutAligned>(from, size, to);
@@ -87,7 +90,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Exp2(const float* from, size_t size, float* to) {
 #if defined(__linux__)
-        if (HaveSve()) Exp2Sve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) Exp2Sve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         Exp2Neon<I_Exact, I_OutAligned>(from, size, to);
@@ -96,7 +99,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Exp2(const double* from, size_t size, double* to) {
 #if defined(__linux__)
-        if (HaveSve()) Exp2Sve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) Exp2Sve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         Exp2Neon<I_Exact, I_OutAligned>(from, size, to);
@@ -105,7 +108,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Exp10(const float* from, size_t size, float* to) {
 #if defined(__linux__)
-        if (HaveSve()) Exp10Sve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) Exp10Sve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         Exp10Neon<I_Exact, I_OutAligned>(from, size, to);
@@ -114,7 +117,7 @@ namespace NFastOps {
     template <bool I_Exact, bool I_OutAligned>
     void Exp10(const double* from, size_t size, double* to) {
 #if defined(__linux__)
-        if (HaveSve()) Exp10Sve<I_Exact, I_OutAligned>(from, size, to);
+        if (SveVectorLengthGt128()) Exp10Sve<I_Exact, I_OutAligned>(from, size, to);
         else
 #endif
         Exp10Neon<I_Exact, I_OutAligned>(from, size, to);

--- a/fastops/sve/ops_sve.cpp
+++ b/fastops/sve/ops_sve.cpp
@@ -25,9 +25,8 @@ bool HaveSve() {
 }
 
 bool SveVectorLengthGt128() {
-    if (!HaveSve())
-        return false;
-    return svcntb() > 16;
+    static bool result = HaveSve() && svcntb() > 16;
+    return result;
 }
 
 // SVE kernel wrappers — call the existing generic kernels with N=0 (SVE VLA tag).


### PR DESCRIPTION
## Summary

- Prefer NEON over SVE when SVE vector length is 128 bits (e.g. AWS Graviton4 / Neoverse V2). At 128-bit width SVE provides no throughput advantage and has measurable overhead from `movprfx`, register pressure, and longer polynomial chains.
- Reduce horizontal reductions in wide NEON `TestCF`/`TestZF` by combining lo/hi halves with a vector OR before the scalar reduction (one `umaxv` instead of two for float, two lane extracts instead of four for double).

## Benchmarks

**Graviton4 (m8g.4xlarge, 128-bit SVE) — dispatched `Log<true>` (double):**

| | Time | vs scalar `log()` |
|---|---|---|
| Before (SVE dispatch) | 0.545 ms | 1.65× slower |
| **After (NEON dispatch)** | **0.265 ms** | **1.25× faster** |

On Graviton4, SVE is slower than NEON across **all** operations. The worst case is exact `log` where SVE is 2× slower than NEON due to callee-save register spills and degree-9 polynomial overhead at only 2 elements per vector.

**Graviton3 (256-bit SVE)** is unaffected — `SveVectorLengthGt128` returns true there, so SVE (1.3–1.5× faster than NEON) is still used.

**Full Graviton4 SVE/NEON comparison (ratio >1 = SVE faster, <1 = NEON faster):**

| Function | Inexact | Exact |
|----------|:---:|:---:|
| exp float | 0.86× | 0.98× |
| exp double | 0.87× | 1.01× |
| log float | 0.78× | **0.46×** |
| log double | 0.81× | **0.50×** |
| sigmoid float | 0.85× | 0.94× |
| sigmoid double | 0.91× | 0.93× |
| tanh float | 0.84× | 0.92× |
| tanh double | 0.89× | 0.92× |

## Test plan

- [x] All unit tests pass on both Graviton3 and Graviton4
- [x] Benchmarked all operations (exp, exp2, exp10, log, sigmoid, tanh) × (float, double) × (exact, inexact) on Graviton4
- [x] Verified dispatched `Log<true>` path switches from SVE to NEON on 128-bit SVE
- [x] Verified Graviton3 (256-bit SVE) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)